### PR TITLE
Add Iconv dependency to CMakeLists.txt

### DIFF
--- a/cras_cpp_common/CMakeLists.txt
+++ b/cras_cpp_common/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2)
+cmake_minimum_required(VERSION 3.11)
 project(cras_cpp_common)
 
 set(CMAKE_CXX_STANDARD 17)  # allows better Eigen alignment handling

--- a/cras_cpp_common/CMakeLists.txt
+++ b/cras_cpp_common/CMakeLists.txt
@@ -34,6 +34,8 @@ find_package(Boost REQUIRED COMPONENTS thread)
 
 find_package(Eigen3 REQUIRED)
 
+find_package(Iconv REQUIRED)
+
 find_package(urdfdom_headers REQUIRED)
 
 # Require https://github.com/ros/filters/pull/60 in the filters package (added in 1.8.3 and 1.9.2)
@@ -233,7 +235,7 @@ target_link_libraries(cras_tf2_utils
 add_library(cras_string_utils src/string_utils.cpp src/string_utils/from_chars.cpp src/string_utils/ros.cpp)
 add_dependencies(cras_string_utils ${catkin_EXPORTED_TARGETS})
 target_link_libraries(cras_string_utils
-  PUBLIC cras_time_utils cras_type_traits ${catkin_LIBRARIES})
+  PUBLIC cras_time_utils cras_type_traits ${catkin_LIBRARIES} Iconv::Iconv)
 if (HAS_FROM_CHARS_FLOAT)
   target_compile_definitions(cras_string_utils PRIVATE HAS_FROM_CHARS_FLOAT=1)
 endif()


### PR DESCRIPTION
Fix error │ │ Undefined symbols for architecture arm64:
 │ │   "_libiconv", referenced from:
 │ │       cras::iconvConvert(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, bool, bool, double, double, std::__1::optional<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>> const&) in string_utils.cpp.o
 │ │   "_libiconv_open", referenced from:
 │ │       cras::iconvConvert(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, bool, bool, double, double, std::__1::optional<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>> const&) in string_utils.cpp.o
 │ │ ld: symbol(s) not found for architecture arm64