### PR TITLE
Fix thread name setting for Apple platform

### DIFF
--- a/cras_cpp_common/src/thread_utils.cpp
+++ b/cras_cpp_common/src/thread_utils.cpp
@@ -40,7 +40,11 @@ void setThreadName(const std::string& name)
     memcpy(nameBuf + 8, name.c_str() + (name.length() - 7), 7);
     nameBuf[15] = '\0';
   }
+#ifdef __APPLE__
+  pthread_setname_np(nameBuf);
+#else
   pthread_setname_np(pthread_self(), nameBuf);
+#endif
 }
 
 }


### PR DESCRIPTION
Fix:
 │ │ $SRC_DIR/ros-noetic-cras-cpp-common/src/work/src/thread_utils.cpp:43:3: error: no matching function for call to 'pthread_setname_np'
 │ │    43 |   pthread_setname_np(pthread_self(), nameBuf);
 │ │       |   ^~~~~~~~~~~~~~~~~~
 │ │ /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/pthread.h:535:5: note: candidate function not viable: requires 1 arg
 │ │ ument, but 2 were provided
 │ │   535 | int     pthread_setname_np(const char*);
 │ │       |         ^                  ~~~~~~~~~~~