### PR TITLE
Remove non-existent website URL from package.xml

### DIFF
--- a/cras_bag_tools/package.xml
+++ b/cras_bag_tools/package.xml
@@ -9,7 +9,6 @@
 
   <license>BSD</license>
 
-  <url type="website">https://wiki.ros.org/cras_bag_tools</url>
   <url type="bugtracker">https://github.com/ctu-vras/ros-utils/issues</url>
   <url type="repository">https://github.com/ctu-vras/ros-utils</url>
 


### PR DESCRIPTION
I was browsing the new Kilted release, but the URL didn't work: https://discourse.openrobotics.org/t/new-packages-for-kilted-kaiju-2026-01-22/52022