### PR TITLE
package.xml: set license to valid SPDX string

### DIFF
--- a/cras_bag_tools/package.xml
+++ b/cras_bag_tools/package.xml
@@ -7,7 +7,7 @@
   <author email="peckama2@fel.cvut.cz">Martin Pecka</author>
   <maintainer email="peckama2@fel.cvut.cz">Martin Pecka</maintainer>
 
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
 
   <url type="website">https://wiki.ros.org/cras_bag_tools</url>
   <url type="bugtracker">https://github.com/ctu-vras/ros-utils/issues</url>

--- a/cras_cpp_common/package.xml
+++ b/cras_cpp_common/package.xml
@@ -7,7 +7,7 @@
   <maintainer email="peckama2@fel.cvut.cz">Martin Pecka</maintainer>
   <author email="peckama2@fel.cvut.cz">Martin Pecka</author>
 
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
 
   <url type="website">https://wiki.ros.org/cras_cpp_common</url>
   <url type="bugtracker">https://github.com/ctu-vras/ros-utils/issues</url>

--- a/cras_docs_common/package.xml
+++ b/cras_docs_common/package.xml
@@ -7,7 +7,7 @@
   <author email="peckama2@fel.cvut.cz">Martin Pecka</author>
   <maintainer email="peckama2@fel.cvut.cz">Martin Pecka</maintainer>
 
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
 
   <buildtool_depend>catkin</buildtool_depend>
 

--- a/cras_py_common/package.xml
+++ b/cras_py_common/package.xml
@@ -7,7 +7,7 @@
   <maintainer email="peckama2@fel.cvut.cz">Martin Pecka</maintainer>
   <author email="peckama2@fel.cvut.cz">Martin Pecka</author>
 
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
 
   <url type="website">https://wiki.ros.org/cras_py_common</url>
   <url type="bugtracker">https://github.com/ctu-vras/ros-utils/issues</url>

--- a/cras_topic_tools/package.xml
+++ b/cras_topic_tools/package.xml
@@ -7,7 +7,7 @@
   <author email="peckama2@fel.cvut.cz">Martin Pecka</author>
   <maintainer email="peckama2@fel.cvut.cz">Martin Pecka</maintainer>
 
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
 
   <url type="website">https://wiki.ros.org/cras_topic_tools</url>
   <url type="bugtracker">https://github.com/ctu-vras/ros-utils/issues</url>

--- a/image_transport_codecs/package.xml
+++ b/image_transport_codecs/package.xml
@@ -7,7 +7,7 @@
   <author email="peckama2@fel.cvut.cz">Martin Pecka</author>
   <maintainer email="peckama2@fel.cvut.cz">Martin Pecka</maintainer>
 
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
 
   <url type="website">https://wiki.ros.org/image_transport_codecs</url>
   <url type="bugtracker">https://github.com/ctu-vras/ros-utils/issues</url>


### PR DESCRIPTION
OpenEmbedded/Yocto needs this info

Note that 'camera-throttle' and 'tl-static-publisher' are missing the LICENSE file.